### PR TITLE
Edited embedded calendar to be visible on mobile layouts

### DIFF
--- a/_sass/ds100.scss
+++ b/_sass/ds100.scss
@@ -141,6 +141,25 @@ ul {
   }
 }
 
+.responsive-calendar-wrapper {
+    position: relative;
+    padding-bottom: 56.25%;
+    padding-top: 30px;
+    height: 0;
+    overflow: hidden;
+}
+ 
+.responsive-calendar-wrapper iframe,   
+.responsive-calendar-wrapper object,  
+.responsive-calendar-wrapper embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+
 .staff {
   display: flex;
   flex-direction: column;

--- a/index.md
+++ b/index.md
@@ -40,11 +40,9 @@ If you have enrolled in the wait-list please complete the following  <a href="ht
  -->
 
 ## Office Hours, Section, and Lab Schedule
-
-<div class="embed-wrapper" style="height:500px">
-  <iframe src="https://calendar.google.com/calendar/embed?title=Data%20100%20Discussion%2C%20Lab%2C%20Office%20Hours&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=berkeley.edu_3iothuu50b7vt60vh265urvkgg%40group.calendar.google.com&amp;color=%2342104A&amp;src=berkeley.edu_q7fe1ocb0v0kdofsf0jb6tnv10%40group.calendar.google.com&amp;color=%23182C57&amp;ctz=America%2FLos_Angeles" style="border-width:0" width="800" height="700" frameborder="0" scrolling="no"></iframe>
+<div class="responsive-calendar-wrapper" style="height: 300px">
+  <iframe src="https://calendar.google.com/calendar/embed?title=Data%20100%20Discussion%2C%20Lab%2C%20Office%20Hours&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=berkeley.edu_3iothuu50b7vt60vh265urvkgg%40group.calendar.google.com&amp;color=%2342104A&amp;src=berkeley.edu_q7fe1ocb0v0kdofsf0jb6tnv10%40group.calendar.google.com&amp;color=%23182C57&amp;ctz=America%2FLos_Angeles" style="border-width:0" frameborder="0" scrolling="no"></iframe>
 </div>
-
 
 For official holidays see the [academic calendar](http://registrar.berkeley.edu/sites/default/files/pdf/UCB_AcademicCalendar_2017-18_V3.pdf).
 


### PR DESCRIPTION
Calendar doesn't show up properly on mobile formats (at least on iOS), so I've created a new wrapper class and re-embedded the calendar in that so it at least shows up. 

[Before](https://i.imgur.com/uhQZztn.png)
[After](https://i.imgur.com/RtNtAaM.png)

(also reported as @263 on Piazza)